### PR TITLE
feat(task-modals): implement NewTaskModal and UpdateTaskModal as standalone, reusable components

### DIFF
--- a/client/task-management-webapp/app/components/TaskItem/NewTaskModal.tsx
+++ b/client/task-management-webapp/app/components/TaskItem/NewTaskModal.tsx
@@ -1,193 +1,207 @@
-import React, { useState } from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import type { TaskItemDto } from "api-client";
-import { TaskItemService, TaskItemSpecialisedService } from "api-client";
+import { TaskItemService } from "api-client";
 
 interface NewTaskModalProps {
-	onClose: () => void;
-	onTaskCreated: (task: TaskItemDto) => void;
+  onClose: () => void;
+  onTaskCreated: (task: TaskItemDto) => void;
+  taskToEdit?: TaskItemDto;
 }
 
 const NewTaskModal: React.FC<NewTaskModalProps> = ({
-	onClose,
-	onTaskCreated,
+  onClose,
+  onTaskCreated,
+  taskToEdit,
 }) => {
-	const [task, setTask] = useState<TaskItemDto>({
-		title: "",
-		description: "",
-		dueDate: undefined,
-		creationTime: new Date(),
-		priority: undefined,
-		progressStatus: undefined,
-		ownerUserId: 1,
-	});
+  const [task, setTask] = useState<TaskItemDto>({
+    title: "",
+    description: "",
+    dueDate: null,
+    creationTime: new Date(),
+    priority: undefined,
+    progressStatus: undefined,
+    ownerUserId: 1, // Placeholder: this can be changed to a prop if needed
+  });
 
-	const handleChange = (field: keyof TaskItemDto, value: any) => {
-		setTask((prev) => ({
-			...prev,
-			[field]: value,
-		}));
-	};
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-	const handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-		if (
-			!task.title ||
-			!task.dueDate ||
-			!task.priority ||
-			!task.progressStatus
-		) {
-			return; // optionally validate with errors
-		}
-		TaskItemService.postApiTasks({ body: task }).then((response) => {
-			console.log(response.data);
-			onTaskCreated(task);
-			onClose();
-		});
-	};
+  useEffect(() => {
+    if (taskToEdit) {
+      setTask({
+        ...taskToEdit,
+        dueDate: taskToEdit.dueDate
+          ? new Date(taskToEdit.dueDate)
+          : undefined,
+      });
+    }
+  }, [taskToEdit]);
 
-	TaskItemSpecialisedService.getApiTasksQueryingByTitlePattern({
-		path: { titlePattern: "title partial name here" },
-	}).then((response) => {
-		console.log(response.data);
-	});
+  const handleChange = (
+    field: keyof TaskItemDto,
+    value: string | number | Date | null | undefined
+  ) => {
+    setTask((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
 
-	return (
-		<div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex justify-center items-center z-50">
-			<div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
-				<h2 className="text-xl font-semibold mb-4 text-gray-800">
-					Create New Task
-				</h2>
-				<form className="space-y-4" onSubmit={handleSubmit}>
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Title
-						</label>
-						<input
-							type="text"
-							placeholder="Task title"
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={task.title ?? ""}
-							onChange={(e) =>
-								handleChange("title", e.target.value)
-							}
-							required
-						/>
-					</div>
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
 
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Description
-						</label>
-						<input
-							type="text"
-							placeholder="Task description"
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={task.description ?? ""}
-							onChange={(e) =>
-								handleChange("description", e.target.value)
-							}
-							required
-						/>
-					</div>
+    if (!task.title || !task.dueDate || task.priority === undefined || task.progressStatus === undefined) {
+      setError("Please fill in all required fields.");
+      return;
+    }
 
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Due Date
-						</label>
-						<input
-							type="date"
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={
-								task.dueDate
-									? new Date(task.dueDate)
-											.toISOString()
-											.split("T")[0]
-									: ""
-							}
-							onChange={(e) =>
-								handleChange(
-									"dueDate",
-									new Date(e.target.value)
-								)
-							}
-							required
-						/>
-					</div>
+    try {
+      setLoading(true);
 
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Priority
-						</label>
-						<select
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={task.priority ?? ""}
-							onChange={(e) =>
-								handleChange("priority", e.target.value)
-							}
-							required
-						>
-							<option value="">Select</option>
-							<option value="High">High</option>
-							<option value="Medium">Medium</option>
-							<option value="Low">Low</option>
-						</select>
-					</div>
+      if (taskToEdit?.id) {
+        await TaskItemService.putApiTasksByTaskId({
+          path: { taskId: taskToEdit.id },
+          body: task,
+        });
+        onTaskCreated({ ...task, id: taskToEdit.id });
+      } else {
+        const response = await TaskItemService.postApiTasks({
+          body: task,
+        });
+        if (response.data) {
+          onTaskCreated(response.data);
+        } else {
+          setError("Failed to create task: No data returned.");
+          setLoading(false);
+          return;
+        }
+      }
 
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Status
-						</label>
-						<select
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={task.progressStatus ?? ""}
-							onChange={(e) =>
-								handleChange("progressStatus", e.target.value)
-							}
-							required
-						>
-							<option value="">Select</option>
-							<option value="Not started">Not started</option>
-							<option value="In progress">In progress</option>
-							<option value="Completed">Completed</option>
-						</select>
-					</div>
+      onClose();
+    } catch (err) {
+      console.error("Error saving task:", err);
+      setError("An error occurred while saving the task.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
-					<div>
-						<label className="block text-sm font-medium text-gray-700 mb-1">
-							Assigned to
-						</label>
-						<input
-							type="number"
-							className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
-							value={task.ownerUserId ?? ""}
-							onChange={(e) =>
-								handleChange(
-									"ownerUserId",
-									Number(e.target.value)
-								)
-							}
-						/>
-					</div>
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-lg w-full max-w-md p-6">
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">
+          {taskToEdit ? "Edit Task" : "Create New Task"}
+        </h2>
 
-					<div className="flex justify-end space-x-2 pt-2">
-						<button
-							type="button"
-							onClick={onClose}
-							className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-100"
-						>
-							Cancel
-						</button>
-						<button
-							type="submit"
-							className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
-						>
-							Save
-						</button>
-					</div>
-				</form>
-			</div>
-		</div>
-	);
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+            <input
+              type="text"
+              className="w-full border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+              value={task.title ?? ""}
+              onChange={(e) => handleChange("title", e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
+            <textarea
+              className="w-full border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+              value={task.description ?? ""}
+              onChange={(e) => handleChange("description", e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Due Date</label>
+            <input
+              type="date"
+              className="w-full border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+              value={
+                task.dueDate
+                  ? new Date(task.dueDate).toISOString().split("T")[0]
+                  : ""
+              }
+              onChange={(e) =>
+                handleChange("dueDate", new Date(e.target.value))
+              }
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Priority</label>
+            <select
+              className="w-full border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+              value={task.priority ?? ""}
+              onChange={(e) =>
+                handleChange("priority", Number(e.target.value))
+              }
+              required
+            >
+              <option value="">Select</option>
+              <option value="0">Low</option>
+              <option value="1">Medium</option>
+              <option value="2">High</option>
+              <option value="3">Critical</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Progress Status</label>
+            <select
+              className="w-full border rounded px-3 py-2 dark:bg-gray-800 dark:text-white"
+              value={task.progressStatus ?? ""}
+              onChange={(e) =>
+                handleChange("progressStatus", Number(e.target.value))
+              }
+              required
+            >
+              <option value="">Select</option>
+              <option value="0">To Do</option>
+              <option value="1">In Progress</option>
+              <option value="2">Completed</option>
+              <option value="3">On Hold</option>
+              <option value="4">Cancelled</option>
+            </select>
+          </div>
+
+          {error && (
+            <p className="text-red-500 text-sm">{error}</p>
+          )}
+
+          <div className="flex justify-end space-x-2">
+            <button
+              type="button"
+              className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-100 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700"
+              onClick={onClose}
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
+              disabled={loading}
+            >
+              {loading
+                ? taskToEdit
+                  ? "Saving..."
+                  : "Creating..."
+                : taskToEdit
+                ? "Save Changes"
+                : "Create Task"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 };
 
 export default NewTaskModal;

--- a/client/task-management-webapp/app/components/TaskItem/UpdateTaskModal.tsx
+++ b/client/task-management-webapp/app/components/TaskItem/UpdateTaskModal.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import type { TaskItemDto } from "api-client";
+import { TaskItemService } from "api-client";
+
+interface UpdateTaskModalProps {
+  taskToUpdate: TaskItemDto;
+  onClose: () => void;
+  onTaskUpdated: (task: TaskItemDto) => void;
+}
+
+const UpdateTaskModal: React.FC<UpdateTaskModalProps> = ({
+  taskToUpdate,
+  onClose,
+  onTaskUpdated,
+}) => {
+  const [task, setTask] = useState<TaskItemDto>(taskToUpdate);
+
+  useEffect(() => {
+    setTask(taskToUpdate);
+  }, [taskToUpdate]);
+
+  const handleChange = (field: keyof TaskItemDto, value: string | number | Date | undefined) => {
+    setTask((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!task.title || !task.dueDate || !task.priority || !task.progressStatus) {
+      return;
+    }
+
+    try {
+      await TaskItemService.putApiTasksByTaskId({
+        path: { taskId: task.id! },
+        body: task,
+      });
+      onTaskUpdated(task);
+      onClose();
+    } catch (err) {
+      console.error("Error updating task:", err);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
+        <h2 className="text-xl font-semibold mb-4 text-gray-800">Edit Task</h2>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+            <input
+              type="text"
+              value={task.title ?? ""}
+              onChange={(e) => handleChange("title", e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <input
+              type="text"
+              value={task.description ?? ""}
+              onChange={(e) => handleChange("description", e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
+            <input
+              type="date"
+              value={task.dueDate ? new Date(task.dueDate).toISOString().split("T")[0] : ""}
+              onChange={(e) => handleChange("dueDate", new Date(e.target.value))}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Priority</label>
+            <select
+              value={task.priority ?? ""}
+              onChange={(e) => handleChange("priority", parseInt(e.target.value))}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
+              required
+            >
+              <option value="">Select</option>
+              <option value="0">Low</option>
+              <option value="1">Medium</option>
+              <option value="2">High</option>
+              <option value="3">Critical</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+            <select
+              value={task.progressStatus ?? ""}
+              onChange={(e) => handleChange("progressStatus", parseInt(e.target.value))}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-gray-900"
+              required
+            >
+              <option value="">Select</option>
+              <option value="0">To Do</option>
+              <option value="1">In Progress</option>
+              <option value="2">Completed</option>
+              <option value="3">On Hold</option>
+              <option value="4">Cancelled</option>
+            </select>
+          </div>
+
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-100"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default UpdateTaskModal;


### PR DESCRIPTION
### Summary

This PR introduces two new standalone components: `NewTaskModal` and `UpdateTaskModal`, designed to be completely decoupled from the `Dashboard` or any specific context. These modals handle task creation and task updates respectively.

### Details

- ✅ `NewTaskModal.tsx` handles task creation with required field validation.
- ✅ `UpdateTaskModal.tsx` allows editing existing tasks based on a passed `TaskItemDto`.
- Both components are **agnostic** and **reusable**. They can be rendered in any component with just 3–4 lines of code.
- Parameters are passed via props (`onClose`, `onTaskCreated`/`onTaskUpdated`, `taskToEdit`).
- UI follows consistent styling with existing project standards.
- Components are ready for integration once the backend authentication (token) is functional.

### Notes

- Task creation/update functionality is wired correctly but cannot be fully tested due to the pending token/auth integration.
- All components are contained within `app/components/TaskItem/` to keep structure organized.
- No changes were made to `Dashboard` as per project guidelines.
